### PR TITLE
arc4random support for *BSD/Darwin/Illumos

### DIFF
--- a/lib/Crypt/Random.pm6
+++ b/lib/Crypt/Random.pm6
@@ -2,8 +2,11 @@ use v6;
 use if;
 use strict;
 
+my constant HAS_ARC4RANDOM = so $*VM.osname ~~ m:i/bsd|darwin|solaris|openindiana|illumos/;
+
 use Crypt::Random::Win:if($*DISTRO.is-win);
-use Crypt::Random::Nix:if(!$*DISTRO.is-win);
+use Crypt::Random::Nix:if(!$*DISTRO.is-win && !HAS_ARC4RANDOM);
+use Crypt::Random::BSD:if(HAS_ARC4RANDOM);
 
 unit module Crypt::Random;
 

--- a/lib/Crypt/Random/BSD.pm6
+++ b/lib/Crypt/Random/BSD.pm6
@@ -1,0 +1,11 @@
+use v6;
+use strict;
+use NativeCall;
+
+sub arc4random_buf(Buf, size_t) is native {*}
+
+sub _crypt_random_bytes(Int $bytes --> Buf) is export {
+    my Buf $buf .= allocate: $bytes;
+    arc4random_buf($buf, $bytes);
+    $buf
+}


### PR DESCRIPTION
OpenBSD doesn't recommend using /dev/urandom for programs, opting for [arc4random](https://man.openbsd.org/urandom) instead.