### PR TITLE
Make system call for getrandom on Nix

### DIFF
--- a/lib/Crypt/Random/Nix.pm6
+++ b/lib/Crypt/Random/Nix.pm6
@@ -1,12 +1,31 @@
 use v6;
 use nqp;
 use strict;
+use NativeCall;
 
 unit module Crypt::Random::Nix;
 
-
+sub syscall ( long, Buf, size_t, uint32 --> ssize_t ) is native {*}
+enum CVar (
+    SYS_getrandom => 318,
+    GRND_NONBLOCK => 0b01,
+);
 
 sub _crypt_random_bytes(uint32 $len) returns Buf is export {
+    return _crypt_random_bytes_urandom($len)
+        if Version.new($*KERNEL.release) < v3.17;
+
+    my $errno     := cglobal ('c', v6), 'errno', int32;
+    my $getrandom := syscall SYS_getrandom,
+        (my Buf $bytes.=allocate: $len), $len, GRND_NONBLOCK;
+
+    die "getrandom() error: errno $errno" if $getrandom == -1;
+    die 'Failed to read enough bytes from getrandom()' if $getrandom != $len;
+
+    $bytes;
+}
+
+sub _crypt_random_bytes_urandom(uint32 $len) returns Buf {
     my $urandom := nqp::open('/dev/urandom', 'r');
     my $bytes   := Buf.new;
 


### PR DESCRIPTION
I've been doing work involving getrandom recently, came across this module while I was exploring, and saw a comment re: getrandom here: https://github.com/skinkade/crypt-random/pull/4.

NativeCall is new to me, so this could use a good set of eyes to make sure all is set up correctly.

Perhaps a flag could be added so that /dev/urandom can be used explicitly?